### PR TITLE
fixes テーブル作成時にインデックスを貼る(貼れなかった)

### DIFF
--- a/development/mysql/sql/V1.sql
+++ b/development/mysql/sql/V1.sql
@@ -7,7 +7,7 @@ ALTER TABLE record             ADD INDEX record_status(status),
                                ADD INDEX record_record_id(record_id),
                                ADD INDEX record_created_by(created_by),
                                ADD INDEX recored_created_at(created_at),
-                               ADD INDEX recored_updated_at(updated_at)
+                               ADD INDEX recored_updated_at(updated_at);
 ALTER TABLE record_item_file   ADD INDEX record_item_file_linked_record_id(linked_record_id),
                                ADD INDEX record_item_file_item_id(item_id);
 ALTER TABLE record_last_access ADD INDEX record_last_access(user_id);

--- a/development/mysql/sql/V1.sql
+++ b/development/mysql/sql/V1.sql
@@ -1,8 +1,17 @@
--- where、order byで2回以上指定されているものにindexをはる
-ALTER TABLE user             ADD INDEX user_user_id(user_id);
-ALTER TABLE category_group   ADD INDEX category_group_group_id(group_id);
-ALTER TABLE record_item_file ADD INDEX record_item_file_linked_record_id(linked_record_id),
-                             ADD INDEX record_item_file_item_id(item_id);
-ALTER TABLE record           ADD INDEX record_record_id(record_id),
-                             ADD INDEX record_created_by(created_by),
-                             ADD INDEX recored_updated_at(updated_at);
+-- where、order byで指定されているもの全てにINDEXを貼っている
+-- TODO: Primary key指定されている場合はいらないかも
+ALTER TABLE user               ADD INDEX user_user_id(user_id);
+ALTER TABLE group_info         ADD INDEX group_info_group_id(group_id);
+ALTER TABLE group_member       ADD INDEX group_member_user_id(user_id);
+ALTER TABLE record             ADD INDEX record_status(status),
+                               ADD INDEX record_record_id(record_id),
+                               ADD INDEX record_created_by(created_by),
+                               ADD INDEX recored_created_at(created_at),
+                               ADD INDEX recored_updated_at(updated_at)
+ALTER TABLE record_item_file   ADD INDEX record_item_file_linked_record_id(linked_record_id),
+                               ADD INDEX record_item_file_item_id(item_id);
+ALTER TABLE record_last_access ADD INDEX record_last_access(user_id);
+ALTER TABLE record_comment     ADD INDEX record_comment_linked_record_id(linked_record_id);
+ALTER TABLE category_group     ADD INDEX category_group_group_id(group_id);
+ALTER TABLE session            ADD INDEX session_value(value);
+ALTER TABLE file               ADD INDEX file_file_id(file_id);


### PR DESCRIPTION
resolve #6 
一意でない列に対してテーブル作成時にインデックスを貼ることができないらしい。
その代わりwhereで使われている要素全てにインデックスを貼った。